### PR TITLE
bug fix: removing file input bg interaction + keeping convert btn disabled initially

### DIFF
--- a/index.html
+++ b/index.html
@@ -14,8 +14,8 @@
 
     <div>
         <label for="resolution_input">Enter resolution:</label>
-        <input type="number" id="resolution_input"/>
-        <button id="process_btn">Convert</button>
+        <input type="number" id="resolution_input" value="30"/>
+        <button id="process_btn" disabled>Convert</button>
     </div>
 
     <canvas id="canvas_input" style="display: none;"></canvas>

--- a/main.js
+++ b/main.js
@@ -23,6 +23,8 @@ const canvas_input_context = canvas_input.getContext("2d", { willReadFrequently:
 function get_file() {
     return __awaiter(this, void 0, void 0, function* () {
         if (!file_input.files || file_input.files.length === 0) {
+            if (is_image_uploaded)
+                return;
             alert("Please upload a .jpg file");
             is_image_uploaded = false;
             return;
@@ -39,6 +41,8 @@ function get_file() {
             img_input.src = canvas_input.toDataURL("image/jpeg");
             img_input.setAttribute("style", "display: block;");
         }
+        process_btn.disabled = false;
+        process_btn.setAttribute("style", "cursor: pointer;");
     });
 }
 function set_pixel_group(new_img_data, pixel, group_width, group_height, group_x, group_y) {

--- a/main.ts
+++ b/main.ts
@@ -14,6 +14,8 @@ const canvas_input_context: CanvasRenderingContext2D | null = canvas_input.getCo
 
 async function get_file(): Promise<void> {
     if (!file_input.files || file_input.files.length === 0) {
+        if (is_image_uploaded) return;
+
         alert("Please upload a .jpg file");
         is_image_uploaded = false;
         return;
@@ -32,6 +34,8 @@ async function get_file(): Promise<void> {
         img_input.src = canvas_input.toDataURL("image/jpeg");
         img_input.setAttribute("style", "display: block;");
     }
+    process_btn.disabled = false;
+    process_btn.setAttribute("style", "cursor: pointer;");
 }
 
 function set_pixel_group(new_img_data: ImageData, pixel: number[], group_width: number, group_height: number, group_x: number, group_y: number): void {

--- a/styles.css
+++ b/styles.css
@@ -54,6 +54,7 @@ input[type="number"] {
     left: 0;
     top: 0;
     opacity: 0;
+    pointer-events: none;
 }
 
 button {
@@ -62,7 +63,7 @@ button {
     margin: 0.5rem;
     font-family: 'Montserrat', sans-serif;
     font-weight: bold;
-    cursor: pointer;
+    cursor: auto;
     transition: background-color 0.3s ease;
 }
 


### PR DESCRIPTION
Issues resolved:

- File input element was clickable in the background. This is no longer occurring, as the interactivity has been disabled.
- The Convert button is disabled initially. When a file is uploaded, it gets enabled